### PR TITLE
[exportResult.R] ZeroAct column missed some values 

### DIFF
--- a/R/exportResult.R
+++ b/R/exportResult.R
@@ -339,7 +339,7 @@ exportResult <- function(cplexSolutionFileName = cplexSolutionFileName, variable
 
         idx <- which(nodesAll[[j]][, 1]==currVar)
 
-        if(nodesAll[[j]][idx, 2]=="0"){
+        if(nodesAll[[j]][idx, 2]=="0" | nodesAll[[j]][idx, 2]=="-0"){
 
           zeroCnt <- zeroCnt + 1
 
@@ -366,13 +366,13 @@ exportResult <- function(cplexSolutionFileName = cplexSolutionFileName, variable
 
       if(nodesAttributes[i, 1]%in%colnames(measurements)){
 
-        nodesAttributes[i, 6] <- "P"
+        nodesAttributes[i, 6] <- "T"
 
       } else {
 
         if(nodesAttributes[i, 1]%in%colnames(inputs)){
 
-          nodesAttributes[i, 6] <- "D"
+          nodesAttributes[i, 6] <- "S"
 
         } else {
 
@@ -384,7 +384,7 @@ exportResult <- function(cplexSolutionFileName = cplexSolutionFileName, variable
 
     }
 
-    colnames(nodesAttributes) <- c("Node", "ZeroAct", "UpAct", "DownAct", "AvgAct", "nodesP")
+    colnames(nodesAttributes) <- c("Node", "ZeroAct", "UpAct", "DownAct", "AvgAct", "NodeType")
 
     # write.table(x = nodesAttributes, file = "nodesAttributes.txt", quote = FALSE, sep = "\t", row.names = FALSE, col.names = TRUE)
     # fileConn3 <- file(paste0("results/",dir_name,"/nodesAttributes_", conditionIDX, ".txt"))

--- a/R/exportResult.R
+++ b/R/exportResult.R
@@ -339,22 +339,40 @@ exportResult <- function(cplexSolutionFileName = cplexSolutionFileName, variable
 
         idx <- which(nodesAll[[j]][, 1]==currVar)
 
-        if(nodesAll[[j]][idx, 2]=="0" | nodesAll[[j]][idx, 2]=="-0"){
-
+        # if(nodesAll[[j]][idx, 2]=="0" | nodesAll[[j]][idx, 2]=="-0"){
+        # 
+        #   zeroCnt <- zeroCnt + 1
+        # 
+        # }
+        # 
+        # if(nodesAll[[j]][idx, 2]=="1"){
+        # 
+        #   upCnt <- upCnt + 1
+        # 
+        # }
+        # 
+        # if(nodesAll[[j]][idx, 2]=="-1"){
+        # 
+        #   downCnt <- downCnt + 1
+        # 
+        # }
+        
+        if(round(as.numeric(nodesActAll[[j]][idx, 2]))==0){
+          
           zeroCnt <- zeroCnt + 1
-
+          
         }
-
-        if(nodesAll[[j]][idx, 2]=="1"){
-
+        
+        if(round(as.numeric(nodesActAll[[j]][idx, 2]))==1){
+          
           upCnt <- upCnt + 1
-
+          
         }
-
-        if(nodesAll[[j]][idx, 2]=="-1"){
-
+        
+        if(round(as.numeric(nodesActAll[[j]][idx, 2]))==-1){
+          
           downCnt <- downCnt + 1
-
+          
         }
 
       }

--- a/R/exportResult.R
+++ b/R/exportResult.R
@@ -357,19 +357,19 @@ exportResult <- function(cplexSolutionFileName = cplexSolutionFileName, variable
         # 
         # }
         
-        if(round(as.numeric(nodesActAll[[j]][idx, 2]))==0){
+        if(round(as.numeric(nodesAll[[j]][idx, 2]))==0){
           
           zeroCnt <- zeroCnt + 1
           
         }
         
-        if(round(as.numeric(nodesActAll[[j]][idx, 2]))==1){
+        if(round(as.numeric(nodesAll[[j]][idx, 2]))==1){
           
           upCnt <- upCnt + 1
           
         }
         
-        if(round(as.numeric(nodesActAll[[j]][idx, 2]))==-1){
+        if(round(as.numeric(nodesAll[[j]][idx, 2]))==-1){
           
           downCnt <- downCnt + 1
           


### PR DESCRIPTION
We observed in the result file 'nodesAttributes_i.txt' that the sum of percentage from 'ZeroAct', 'UpAct' and 'DownAct' columns is not always 100(%). A careful inspection revealed that this issue seems to be arisen from the column 'ZeroAct' and not the other two as the values in this column sometimes didn't fill up to 100% even if the respective node is not included in any solution network.

![zeroactissueorig](https://user-images.githubusercontent.com/20519860/53012637-da36fa00-3443-11e9-8ef0-917f825d8d69.png)

Taking CARNIVAL Example 3 (InvCARNIVAL-APAP) as an example, the exported node activity of P29320 (EPHA3) on 'ZeroAct' is just 1.266% while being 0 in the other columns. 

![zeroactissue1](https://user-images.githubusercontent.com/20519860/53012889-8e388500-3444-11e9-9898-dc0bc5875593.png)

Checking at the variable level, this species takes the variable name 'xb40_1' in the LP description file.

![zeroactissue2](https://user-images.githubusercontent.com/20519860/53012896-9395cf80-3444-11e9-90d9-23bba6a2f284.png)

In the written LP solution file (result_cplex_i_j.txt), it was shown that the solution of this variable is either "0" in 1 out of 79 (1.266%) while it take values "-0" in the other 78 solutions. It seems to be clear here that the current exportResults.R script takes only the matched string "0" but not "-0" into account. A correction is therefore needed (see commit).

![zeroactissue3](https://user-images.githubusercontent.com/20519860/53013643-91347500-3446-11e9-9a8a-a2d4818105fc.png)

![zeroactissue4](https://user-images.githubusercontent.com/20519860/53013649-942f6580-3446-11e9-8a3c-c190e020d96e.png)

After the correction, the results are now correctly exported e.g. for the node P29320 where ZeroAct is now at 100(%), see below. Please also note that we revised the column name "nodesP" and the annotation marks "P" and "D" to become "NodeType" with annotation markers "S" and "T" to intuitively represent source and target nodes, respectively.

![zeroactissuesolved](https://user-images.githubusercontent.com/20519860/53013166-5da51b00-3445-11e9-95c8-4a094745b2b2.png)

@enio23 - could you please double check and merge the branch if there is no further issue? Thanks!