### PR TITLE
Fix parallelisation pipeline

### DIFF
--- a/R/runCARNIVAL.R
+++ b/R/runCARNIVAL.R
@@ -117,7 +117,7 @@ runCARNIVAL <- function(CplexPath=NULL,
   if (parallelIdx1==1 & parallelIdx2==1) { # default case
     repIndex=1;condition=1
   } else {
-    repIndex=parallelIdx1;condition=parallelIdx2
+    condition=parallelIdx1;repIndex=parallelIdx2
   }
 
   # Create a directory to store results

--- a/README.md
+++ b/README.md
@@ -192,6 +192,30 @@ enrichCARNIVAL(Result_dir="Results_CARNIVAL_Ex3",
 
 The enrichment results will be saved in the designated 'Result_dir' folder. All pathways with p-value < 0.5 will be included in a csv file and enrichment figures, both combined up- and down-regulated as well as the separated version can be selected for plotting (see options in the enrichCARNIVAL function).
 
+### Running CARNIVAL on a parallelised cluster
+
+To facilitate the running of parallelised jobs on a clustered computer, CARNIVAL also offers an option to set the tag-number for each individual run (currently up to two numbers, onto the variables "parallelIdx1" and "parallelIdx2" - set to 1 and 1 by default). This assighment prevents the overwriting of the linear integer (LP) constraints file as well as of the exported result file from CPLEX with the same filename. In this case, users has to prepare a separated (driver) R-script to load necessary libraries and assign inputs of the runCARNIVAL function which can then be called from bash/shell/command prompt. An example for setting up the pipeline using CARNIVAL Ex2 as an example is provided below.
+
+```R
+# --- Save the code below into an R-script e.g. runParallelCARNIVAL.R --- #
+
+library(CARNIVAL) # load CARNIVAL library
+library(doParallel) # load parallel job library
+argsJob=commandArgs(trailingOnly = TRUE)
+CARNIVAL_Result <- runCARNIVAL(CplexPath="~/Applications/IBM/ILOG/CPLEX_Studio1281/cplex/bin/x86-64_osx/cplex",
+            Result_dir="Results_CARNIVAL_Ex2_Parallel",
+            CARNIVAL_example=2,
+	    parallelIdx1 = as.numeric(argsJob[1]),
+            parallelIdx2 = as.numeric(argsJob[2])
+	    )
+```
+
+After saving the code into an R-script, users can launch the pipeline with the command 'Rscript' on batch/shell/command prompt followed by the filename of the R-script and the two tag-numbers (here e.g. '2' and '3'). These numbers should be changed accordingly upon running the jobs in parallel on a cluster. Please refer to the documentation on how to run a parallelised job on the cluster that you are working with as each cluster has their own command/argument to submit and initiate the job.
+
+```Console
+>>> Rscript runParallelCARNIVAL.R 2 3
+```
+
 ## Authors
 
 Panuwat Trairatphisan (panuwat.trairatphisan -at- gmail.com)

--- a/man/runCARNIVAL.Rd
+++ b/man/runCARNIVAL.Rd
@@ -6,11 +6,12 @@
 \usage{
 runCARNIVAL(CplexPath = NULL, netFile = NULL, measFile = NULL,
   inputFile = NULL, weightFile = NULL, CARNIVAL_example = 2,
-  Result_dir = "Results_CARNIVAL", inverseCR = F, parallelCR = F,
-  nodeID = "uniprot", UP2GS = T, DOTfig = T, Export_all = F,
-  timelimit = 600, mipGAP = 0.05, poolrelGAP = 1e-04,
-  limitPop = 500, poolCap = 100, poolIntensity = 4,
-  poolReplace = 2, alphaWeight = 1, betaWeight = 0.2)
+  Result_dir = "Results_CARNIVAL", inverseCR = F, parallelIdx1 = 1,
+  parallelIdx2 = 1, nodeID = "uniprot", UP2GS = T, DOTfig = T,
+  Export_all = F, timelimit = 600, mipGAP = 0.05,
+  poolrelGAP = 1e-04, limitPop = 500, poolCap = 100,
+  poolIntensity = 4, poolReplace = 2, alphaWeight = 1,
+  betaWeight = 0.2)
 }
 \arguments{
 \item{CplexPath}{Path to executable cplex file - always required}
@@ -29,7 +30,9 @@ runCARNIVAL(CplexPath = NULL, netFile = NULL, measFile = NULL,
 
 \item{inverseCR}{Execute the inverse CARNIVAL pipeline (logical T/F)}
 
-\item{parallelCR}{Execute the parallelised version of CARNIVAL pipeline (logical T/F)}
+\item{parallelIdx1}{First index number suitable for parallelisation (numeric - set to 1 by default)}
+
+\item{parallelIdx2}{Second index number suitable for parallelisation (numeric - set to 1 by default)}
 
 \item{nodeID}{Define the input format of nodes in the network (either 'uniprot' or 'gene' symbol)}
 


### PR DESCRIPTION
- As of current, the option 'parallelCR' on the runCARNIVAL function works only when plugging the argJobs statement directly from the cluster to the function itself. Nevertheless, a common approach for running CARNIVAL on a cluster is to have a separated driver script which call the runCARNIVAL function inside so the argJobs statement will not be transferred in this case.
- To address issue, we removed the option 'parallelCR' and introduced two indices numeric parameters 'parallelIdx1' and 'parallelIdx2' in the runCARNIVAL function for which the users can directly map the argJobs statement to the function.
- The new implementation is currently tested by Angeliki Kalamara. More updates will be posted soon.