### PR TITLE
Update solvers_cplex__solve_cplex.R

### DIFF
--- a/R/solvers_cplex__solve_cplex.R
+++ b/R/solvers_cplex__solve_cplex.R
@@ -9,7 +9,7 @@ solveWithCplex <- function(carnivalOptions) {
     # TODO: implement logging on Win machine. 
     #TODO why copying exe and not directly executing it? 
     file.copy(from = carnivalOptions$solverPath, to = getwd())
-    system(paste0("cplex.exe -f", cplexCommandFilename))
+    system(paste0("cplex.exe -f ", cplexCommandFilename))
     file.remove("cplex.exe")
   } else {
     system(paste0(carnivalOptions$solverPath, " -f ", cplexCommandFilename,


### PR DESCRIPTION
Bug fix on the cplex.exe call in a Windows machine. There was a space missing after -f.